### PR TITLE
Add GameSir G7 SE support (input-only, evdev)

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -173,9 +173,11 @@ No. It's all local USB — no network, no telemetry, no account. Even the firmwa
 *version* is read straight from the USB descriptor, not fetched online.
 
 **Will it work with my other GameSir controller?**
-Only the **Cyclone 2** and **G7 Pro** have been tested; anything else is
-unsupported and untested. The app **refuses state-changing writes to a device it
-can't positively recognize**, so an unknown model reads but won't be written.
+The **Cyclone 2** and **G7 Pro 8K PC** are fully supported, and the **G7 SE** is
+recognized for input (its config channel isn't reverse-engineered, so its config
+editor is disabled). Anything else is unsupported and untested. The app **refuses
+state-changing writes to a device it can't positively recognize**, so an unknown
+model reads but won't be written.
 
 **Do I need `sudo`?**
 No — install the udev rule once and your user gets access. `sudo` is only a

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@
 A Linux GUI for gaming input devices, driven over each device's vendor (hidraw)
 interface, reverse-engineered from scratch. Currently supports the **GameSir
 Cyclone 2** and **G7 Pro 8K PC** controllers and the **Logitech G502 X LIGHTSPEED**
-mouse (see Tested hardware); the protocol modules are per-vendor
+mouse (see Tested hardware), and recognizes the **GameSir G7 SE** for input; the
+protocol modules are per-vendor
 (`vendors/gamesir`, `vendors/logitech`), so other manufacturers can be added
 alongside. It covers:
 
@@ -71,7 +72,10 @@ This is a hobby reverse-engineering project; fork it and customize it however yo
 > a **GameSir G7 Pro 8K PC**, and a **Logitech G502 X LIGHTSPEED** mouse — **nothing
 > else.** (A regular, non-8K **G7 Pro** was also tested but does **not** work: it's
 > an Xbox-only pad whose config channel Linux doesn't expose — input works, config
-> is blocked. See [RESEARCH.md](RESEARCH.md).)
+> is blocked. See [RESEARCH.md](RESEARCH.md).) A **GameSir G7 SE** is recognized and
+> its input works over evdev (a normal gamepad), but its config channel isn't
+> reverse-engineered — it is input-only: the config/lighting/macro editors are
+> disabled for it.)
 > Other GameSir controllers, other Logitech mice, other dongles, and firmware
 > revisions we haven't seen are **unsupported and untested** and may misbehave. The
 > app won't send config writes to a device it can't positively recognize, but
@@ -244,7 +248,8 @@ everything it does is **reversible** and stays **on your machine**. The specific
   online.
 - **Permissions.** Prefer the udev rule (per-user `uaccess`) over running as root —
   see [Running](#running). Under `sudo`, `~` is `/root`, so backups land there.
-- **Tested hardware.** Only the Cyclone 2 and G7 Pro 8K PC (see the note up top). Treat
+- **Tested hardware.** Only the Cyclone 2 and G7 Pro 8K PC (see the note up top). The
+  G7 SE is recognized for input only (config channel not reverse-engineered). Treat
   anything else as unproven and use it at your own risk.
 
 ## How it works

--- a/RESEARCH.md
+++ b/RESEARCH.md
@@ -15,7 +15,7 @@ re-tread them. This is a hobby RE effort; corrections and additions welcome.
 |---|---|---|---|---|---|
 | **Cyclone 2** | `0575` / `100b` / `1053` | ✅ vendor `0x12` | ✅ full | ✅ (JieLi BR23) | **Fully supported** |
 | **G7 Pro** | `1022` (PC/HID) · `100a`/`10ba`/`10bb` (Xbox/GIP) | ✅ evdev | ❌ blocked (see below) | — (different chip) | **Input only** |
-| G7 SE *(not owned)* | `1010` | ✅ mainline `xpad` | n/a | — | Reference only |
+| G7 SE *(not owned)* | `1010` (also `1082` in the wild) | ✅ evdev (recognized) | ⛔ not RE'd (input-only) | — | Input supported |
 | G7 Pro 8K *(incoming)* | TBD | TBD | *likely ✅* — uses **Connect** | TBD | To be tested |
 | 8BitDo *(future)* | — | — | — | — | Not started |
 
@@ -164,6 +164,16 @@ Being an Xbox-One entry, it presents a GIP identity that `xpad`/`xone` bind dire
 **Whether it also has a PC/HID mode like the tri-mode Pro is unknown to us** — we don't
 own one; this section is reference, not a tested finding. Source:
 [`drivers/input/joystick/xpad.c`](https://github.com/torvalds/linux/blob/master/drivers/input/joystick/xpad.c).
+
+**Deadband support (input-only).** The app now *recognizes* the G7 SE (`0x1010`, and
+`0x1082` — reported by a unit in the wild as "GameSir-G7 SE Controller for Xbox") as an
+`evdev` input profile, so it shows up as **G7 SE**, live input works over the standard
+gamepad node, and the false "not in Xbox mode" warning no longer appears (the reader's
+Cyclone `0x12` heuristic previously mis-branded it, since a GIP pad never emits that
+report). The vendor config channel is **not reverse-engineered** (it may be inert on
+Linux like the G7 Pro's PC/HID face), so the profile deliberately exposes no register
+addresses: config, lighting, macros and flash are all disabled until captures of the
+official app are decoded.
 
 ---
 

--- a/controller_profile.py
+++ b/controller_profile.py
@@ -351,6 +351,34 @@ G7_PRO = ControllerProfile(
 )
 
 
+# --- G7 SE : GameSir G7 SE (3537:1010 wired) ---------------------------------
+# A wired Xbox-style pad (GIP; listed in mainline `xpad` as 3537:1010,
+# XTYPE_XBOXONE, added in kernel 6.14 — see RESEARCH.md). INPUT-ONLY support:
+# like the G7 Pro, live input arrives over evdev (a standard gamepad), so the
+# reader must route it through the evdev path — otherwise the Cyclone 0x12
+# heuristic (reader.py) brands a perfectly live pad "not in Xbox mode" forever.
+#
+# The vendor config channel is NOT reverse-engineered (and, like the G7 Pro's
+# PC/HID face, may be inert on Linux), so this profile deliberately exposes NO
+# register addresses: read_fields() is empty, the config editor offers nothing,
+# and the send_cmd recognized-model guard (vendors/gamesir/control.py) means no
+# state-changing write can reach the device. Add the register map here once a
+# capture of the official app is decoded.
+#
+# 0x1082 is included alongside the documented 0x1010: a unit in the wild
+# enumerated as 3537:1082 "GameSir-G7 SE Controller for Xbox" (doctor report),
+# plausibly a hardware revision — recognizing both is harmless.
+G7_SE = ControllerProfile(
+    name='GameSir G7 SE',
+    short='G7 SE',
+    usb_products=(0x1010, 0x1082),
+    wired_products=(0x1010, 0x1082),    # wired-only model; no wireless dongle
+    input_style='evdev',                # GIP input on the standard gamepad node
+    profile_banks=(),                   # no editable config until the vendor
+                                        # channel is reverse-engineered
+)
+
+
 # --- G7 Pro 8K : GameSir G7 Pro 8K (3537:10c7 wired / 3537:10c8 wireless) ----
 # Reverse-engineered 2026-07-07 from live vendor-channel probing + 11 USBPcap
 # captures of the official app (see the `g7-pro-8k` memory + "Controller Testing/
@@ -484,7 +512,7 @@ G7_8K = ControllerProfile(
 
 
 # --- registry + detection ----------------------------------------------------
-ALL = (CYCLONE, G7, G7_PRO, G7_8K)
+ALL = (CYCLONE, G7, G7_PRO, G7_SE, G7_8K)
 DEFAULT = CYCLONE
 
 


### PR DESCRIPTION
## What
Recognize the **GameSir G7 SE** (wired Xbox-style pad) as an evdev input profile so the app stops mis-reporting it as "not in Xbox mode".

## Why
The G7 SE was not in the `controller_profile` registry, so `detect_one()` returned `None`. The reader then fell back to the Cyclone `0x12` path ([reader.py](reader.py)): it opened the vendor hidraw node and applied the all-zero-`0x12` heuristic, which permanently set `mode_ok = False` because a GIP/Xbox controller never emits the Cyclone-style populated `0x12` report. Result: the header showed "Not in Xbox mode" even though the pad was already in its correct Xbox/XInput mode.

## What changed
- New `G7_SE` profile in [controller_profile.py](controller_profile.py): `input_style='evdev'`, `usb_products=(0x1010, 0x1082)`, `wired_products=(0x1010, 0x1082)`.
  - `0x1010` is the PID listed in mainline `xpad` (kernel 6.14); `0x1082` is what the unit this was developed against actually enumerates as (`GameSir 1082 "GameSir-G7 SE Controller for Xbox"` per `deadband --doctor`).
- Registered `G7_SE` in the `ALL` registry.
- Docs updated: README (tested hardware + intro), RESEARCH.md (G7 SE section + summary table), MANUAL.md (FAQ).

## Deliberately NOT included (input-only)
The vendor **config channel is not reverse-engineered** (and, like the G7 Pro's PC/HID face, may be inert on Linux). The profile therefore exposes **no register addresses**: `read_fields()` is empty, the config/lighting/macro/flash editors are disabled, and the existing `send_cmd` recognized-model guard ([vendors/gamesir/control.py](vendors/gamesir/control.py)) means no state-changing write can reach the device. This matches the upstream safety model (writes only to positively-recognized, mapped models).

## Verified (read-only, on the target hardware)
- `deadband --doctor`: both hidraw nodes open OK, PID `0x1082`.
- `find_controllers()` → port `7-1`, PID `0x1082` → resolves to **G7 SE**, `input_style='evdev'`, `wired=True`.
- The G7 SE's gamepad evdev node reports `Vendor=0x3537` (matches `VENDOR_VID`), so `read_session_evdev`/`press_select_loop` pick it up and `mode_ok` clears — the false warning is gone.
- All modules `py_compile` clean.